### PR TITLE
Add menu drawer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Header from './components/header/header.component';
 import menu from './data/menu.data.js';
 import './App.css';
+import DrawerMenu from './components/DrawerMenu/DrawerMenu';
+import BackgroundShadow from './components/BackgroundShadow/BackgroundShadow';
 
 function App() {
 	let MENU_DATA = menu(React);
+	const [isMenuVisible, setIsMenuVisible] = useState(false);
+	const toggleDrawerHandler = () => {
+		setIsMenuVisible(!isMenuVisible);
+	};
 	return (
-		<div>
-			{/*<Header menuData={MENU_DATA} />*/}
+		<div style={{ height: '100%' }}>
+			<Header menuData={MENU_DATA} toggleDrawerHandler={toggleDrawerHandler} />
+			<DrawerMenu show={isMenuVisible} toggleDrawerHandler={toggleDrawerHandler} menuData={MENU_DATA} />
+			{isMenuVisible ? <BackgroundShadow hideShadowHandler={toggleDrawerHandler} />: null }
 			{MENU_DATA.map((menu, index) => (
 				<menu.componente key={index} reference={menu.reference} />
 			))}

--- a/src/components/BackgroundShadow/BackgroundShadow.jsx
+++ b/src/components/BackgroundShadow/BackgroundShadow.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import './BackgroundShadow.scss'
+
+class BackgroundShadow extends React.Component {
+
+
+    render() {
+        const hideShadow=this.props.hideShadowHandler;
+        return (
+            <div className="background-shadow" onClick={() => {
+                hideShadow();
+            }}/>
+        );
+    }
+}
+
+export default BackgroundShadow;

--- a/src/components/BackgroundShadow/BackgroundShadow.scss
+++ b/src/components/BackgroundShadow/BackgroundShadow.scss
@@ -1,0 +1,9 @@
+.background-shadow {
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    background-color: rgba($color: #000000, $alpha: 0.3);
+    z-index: 50;
+    top: 0;
+    left: 0;
+}

--- a/src/components/DrawerMenu/DrawerMenu.jsx
+++ b/src/components/DrawerMenu/DrawerMenu.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import './DrawerMenu.scss';
+
+class DrawerMenu extends React.Component {
+
+	handleScrollTo = (ref) => {
+		const el = ref.current || ref;
+		if (el && el.scrollIntoView) {
+			// Scroll the element into view
+			el.scrollIntoView({
+				behavior: 'smooth',
+				block: 'start'
+			});
+		}
+
+	};
+
+
+    render() {
+        const toggleDrawerHandler = this.props.toggleDrawerHandler;
+        const isOpen = this.props.show;
+        let drawerClasses = ['drawer']
+        if (isOpen)
+            drawerClasses = ['drawer', 'drawer-open']
+        return (
+            <nav className={drawerClasses.join(" ")}>
+                <ul>
+                    {this.props.menuData.map((menu, index) => (
+                        <li><a
+                            key={index}
+                            className="option"
+                            onClick={() => {
+                                toggleDrawerHandler();
+                                this.handleScrollTo(menu.reference);
+                            }}
+                        >
+                            {menu.name}
+                        </a></li>
+                    ))}
+                </ul>
+            </nav>
+        );
+    }
+}
+
+export default DrawerMenu;

--- a/src/components/DrawerMenu/DrawerMenu.scss
+++ b/src/components/DrawerMenu/DrawerMenu.scss
@@ -1,0 +1,39 @@
+.drawer {
+    height: 100%;
+    background: #4f5cab;
+    box-shadow: 0px 0px 5px 2px rgba($color: #000000, $alpha: 0.5);
+    position: fixed;
+    top: 0;
+    right: 0;
+    max-width: 400px;
+    width: 80%;
+    z-index: 100;
+    transform: translateX(100%);
+    transition: transform 0.3s ease-out;
+    ul {
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        height: 100%;
+        li {
+            margin: 0.5rem 0;
+            a {
+                color: #ffffff;
+                cursor: pointer;
+            }
+        }
+    }
+    .option {
+        padding: 10px 15px;
+        text-decoration: none;
+        font-size: 1.2rem;
+        &:first-of-type {
+            flex: 1;
+        }
+
+    }
+}
+.drawer-open {
+    transform: translateX(0%);
+}

--- a/src/components/DrawerMenu/ToggleButton.jsx
+++ b/src/components/DrawerMenu/ToggleButton.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import './ToggleButton.scss'
+
+class ToggleButton extends React.Component {
+
+
+    render() {
+        return (
+            <button onClick={this.props.onClick} className="drawer-toggle-button">
+                ☰
+            </button>
+        );
+    }
+}
+
+export default ToggleButton;

--- a/src/components/DrawerMenu/ToggleButton.scss
+++ b/src/components/DrawerMenu/ToggleButton.scss
@@ -1,0 +1,13 @@
+.drawer-toggle-button {
+    height: 24px;
+    width: 34px;
+    background: transparent;
+    border: white solid 1px;
+    border-radius: 3px;
+    color: white;
+}
+@media(min-width: 769px) {
+    .drawer-toggle-button {
+        display: none;
+    }
+}

--- a/src/components/header/header.component.jsx
+++ b/src/components/header/header.component.jsx
@@ -1,33 +1,43 @@
 import React from 'react';
 import './header.styles.scss';
+import ToggleButton from '../DrawerMenu/ToggleButton';
 
 class Header extends React.Component {
 	handleScrollTo = (ref) => {
-		const el = ref.current ? ref.current : ref;
+		const el = ref.current || ref;
+		if (el && el.scrollIntoView) {
+			// Scroll the element into view
+			el.scrollIntoView({
+				behavior: 'smooth',
+				block: 'start'
+			});
+		}
 
-		// Scroll the element into view
-		el.scrollIntoView({
-			behavior: 'smooth',
-			block: 'start'
-		});
 	};
 
 	render() {
 		return (
 			<div className="Header">
-				<div className="options-container">
-					{this.props.menuData.map((menu, index) => (
-						<span
-							key={index}
-							className="option"
-							onClick={() => {
-								this.handleScrollTo(menu.reference);
-							}}
-						>
-							{menu.name}
-						</span>
-					))}
-				</div>
+				<nav className="header-navigation">
+					<div className="options-container">
+						<ul>
+							{this.props.menuData.map((menu, index) => (
+								<li><a
+									key={index}
+									className="option"
+									onClick={() => {
+										this.handleScrollTo(menu.reference);
+									}}
+								>
+									{menu.name}
+								</a></li>
+							))}
+						</ul>
+					</div>
+					<ToggleButton onClick={() => {
+						this.props.toggleDrawerHandler()
+					}}></ToggleButton>
+				</nav>
 			</div>
 		);
 	}

--- a/src/components/header/header.styles.scss
+++ b/src/components/header/header.styles.scss
@@ -2,7 +2,8 @@
 	width: 100%;
 	height: 70px;
 	display: flex;
-	justify-content: space-between;
+	justify-content: end;
+	align-items: center;
 	margin-bottom: 25px;
 	background-color: #4f5cab;
 	position: fixed;
@@ -17,9 +18,34 @@
 		cursor: pointer;
 		.option {
 			padding: 10px 15px;
+			text-decoration: none;
 			&:first-of-type {
 				flex: 1;
 			}
+
 		}
 	}
+}
+.header-navigation{
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+	width: 100%;
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		li {
+			padding: 0 0.5rem;
+		}
+	}
+	button {
+		margin-right: 0.5rem;
+	}
+}
+@media(max-width: 768px) {
+    .options-container  {
+		display: none !important;
+    }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+html {
+  height: 100%;
+}
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -5,6 +8,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  height: 100%;
 }
 
 code {

--- a/src/pages/problem/problem.component.jsx
+++ b/src/pages/problem/problem.component.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import FirstSecProblem from '../../components/problem/first-sec-problem/first-sec-problem.component';
 const Problem = ({ reference }) => (
-	<div className="section">
+	<div ref={reference} className="section">
 		<FirstSecProblem />
 	</div>
 );

--- a/src/pages/welcome/welcome.component.jsx
+++ b/src/pages/welcome/welcome.component.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import FirstSecWelcome from '../../components/welcome/first-sec-welcome/first-sec-welcome.component';
-const Welcome = () => (
-	<div className="section">
+const Welcome = ({reference}) => (
+	<div ref={reference} className="section">
 		<FirstSecWelcome />
 	</div>
 );


### PR DESCRIPTION
I added a new button menu that users can click on whenever they are on
mobile phones (i used <768px as a breakpoint).

When the button is clicked a drawer will be shown with the navbar items
so that the user can navigate around the page.

I also created a reusable shadow component that can be used with
modals or drawers.